### PR TITLE
Fix deprecated graphconncomp

### DIFF
--- a/Label_Graph_Components.m
+++ b/Label_Graph_Components.m
@@ -63,7 +63,7 @@ ind = find(Mat);
 LabNet = sparse(size(Mat,1),size(Mat,2));
 
 % ---------- Detecting Graph Components 
-[Nclust,allclust] = conncomp(sparse(logical(Mat)));
+[Nclust,allclust] = conncomp_rep(sparse(logical(Mat)));
 allclust = allclust(:);
 temp = accumarray(allclust,allclust*0+1);
 clust = find(temp>=2);

--- a/Label_Graph_Components.m
+++ b/Label_Graph_Components.m
@@ -63,7 +63,7 @@ ind = find(Mat);
 LabNet = sparse(size(Mat,1),size(Mat,2));
 
 % ---------- Detecting Graph Components 
-[Nclust,allclust] = graphconncomp(sparse(logical(Mat)));
+[Nclust,allclust] = conncomp(sparse(logical(Mat)));
 allclust = allclust(:);
 temp = accumarray(allclust,allclust*0+1);
 clust = find(temp>=2);

--- a/conncomp_rep.m
+++ b/conncomp_rep.m
@@ -1,0 +1,17 @@
+function [S,C] = conncomp(G)
+  % CONNCOMP Drop in replacement for graphconncomp.m from the bioinformatics
+  % toobox. G is an n by n adjacency matrix, then this identifies the S
+  % connected components C. This is also an order of magnitude faster.
+  %
+  % [S,C] = conncomp(G)
+  %
+  % Inputs:
+  %   G  n by n adjacency matrix
+  % Outputs:
+  %   S  scalar number of connected components
+  %   C  
+  [p,q,r] = dmperm(G+speye(size(G)));
+  S = numel(r)-1;
+  C = cumsum(full(sparse(1,r(1:end-1),1,1,size(G,1))));
+  C(p) = C;
+end

--- a/conncomp_rep.m
+++ b/conncomp_rep.m
@@ -1,4 +1,4 @@
-function [S,C] = conncomp(G)
+function [S,C] = conncomp_rep(G)
   % CONNCOMP Drop in replacement for graphconncomp.m from the bioinformatics
   % toobox. G is an n by n adjacency matrix, then this identifies the S
   % connected components C. This is also an order of magnitude faster.


### PR DESCRIPTION
MATLAB's graphconncomp function was deprecated. This pull request aims to fix that replacing graphconncomp with another function.